### PR TITLE
feat(ui): Replace filter panel with modern slide-over drawer

### DIFF
--- a/client/src/app/components/ActionStatusDashboard.tsx
+++ b/client/src/app/components/ActionStatusDashboard.tsx
@@ -65,7 +65,6 @@ export default function ActionStatusDashboard({
     manualRefresh
   } = useAutoRefresh(refreshWorkflows, { interval: 30, enabled: selectedRepos.length > 0 });
 
-  // Filtros de tipo e busca (iguais à aba de repositórios)
   const [repoFilter, setRepoFilter] = useState<'all' | 'personal' | 'organization'>('all');
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -183,7 +182,7 @@ export default function ActionStatusDashboard({
             </svg>
             <span className="sr-only">Exit Fullscreen</span>
           </button>
-          <div className="columns-1 sm:columns-2 md:columns-3 lg:columns-4 xl:columns-5 2xl:columns-6 3xl:columns-8 pb-4 mt-12" style={{ columnWidth: '340px', columnGap: '16px' }}>
+          <div className="columns-1 sm:columns-2 md:columns-3 lg:columns-4 xl:columns-5 2xl:columns-6 3xl:columns-8 4xl:columns-9 pb-4 mt-12" style={{ columnWidth: '340px', columnGap: '16px' }}>
             {filteredRepos.map((repo) => {
               if (!repo) return null;
               const repoWorkflows = workflows[repo.id] || [];
@@ -311,7 +310,7 @@ export default function ActionStatusDashboard({
           <p>Select repositories to view their action status</p>
         </div>
       ) : (
-        <div className="columns-1 sm:columns-2 md:columns-3 lg:columns-4 xl:columns-5 2xl:columns-6 3xl:columns-8 pb-4" style={{ columnWidth: '340px', columnGap: '16px' }}>
+        <div className="columns-1 sm:columns-2 md:columns-3 lg:columns-4 xl:columns-5 2xl:columns-6 3xl:columns-8 4xl:columns-9 pb-4" style={{ columnWidth: '340px', columnGap: '16px' }}>
           {filteredRepos.map((repo) => {
             if (!repo) return null;
             const repoWorkflows = workflows[repo.id] || [];

--- a/client/src/app/components/FilterPanel.tsx
+++ b/client/src/app/components/FilterPanel.tsx
@@ -17,6 +17,7 @@ interface Props {
   setSortOrder: (val: 'asc' | 'desc') => void;
   sortBy: 'name' | 'full_name' | 'updated_at';
   setSortBy: (val: 'name' | 'full_name' | 'updated_at') => void;
+  onClose?: () => void;
 }
 
 export default function FilterPanel({
@@ -31,6 +32,7 @@ export default function FilterPanel({
   setSortOrder,
   sortBy,
   setSortBy,
+  onClose,
 }: Props) {
   const [viewMode, setViewMode] = useState<'simple' | 'detailed'>('simple');
   
@@ -76,38 +78,51 @@ export default function FilterPanel({
     });
 
   return (
-    <div className={`${viewMode === 'detailed' ? 'w-96' : 'w-80'} max-w-full h-full overflow-y-auto bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 p-4 space-y-4`}>
+    <div className={`${viewMode === 'detailed' ? 'w-96' : 'w-80'} max-w-full h-full overflow-y-auto bg-white dark:bg-gray-900 p-4 space-y-4`}>
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Repositories</h2>
         
-        {/* View Mode Toggle */}
-        <div className="flex items-center bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
-          <button
-            onClick={() => setViewMode('simple')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
-              viewMode === 'simple'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-            }`}
-            title="Simple view"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
-            </svg>
-          </button>
-          <button
-            onClick={() => setViewMode('detailed')}
-            className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
-              viewMode === 'detailed'
-                ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-                : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-            }`}
-            title="Detailed view"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-          </button>
+        <div className="flex items-center gap-2">
+          {/* View Mode Toggle */}
+          <div className="flex items-center bg-gray-100 dark:bg-gray-800 rounded-lg p-1">
+            <button
+              onClick={() => setViewMode('simple')}
+              className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+                viewMode === 'simple'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+              title="Simple view"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+            </button>
+            <button
+              onClick={() => setViewMode('detailed')}
+              className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
+                viewMode === 'detailed'
+                  ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+              }`}
+              title="Detailed view"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+            </button>
+          </div>
+          {onClose && (
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 transition-colors"
+              title="Close panel"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
 

--- a/client/src/app/dashboard/page.tsx
+++ b/client/src/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ function DashboardContent() {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [selectedRepos, setSelectedRepos] = useState<number[]>([]);
   const [loading, setLoading] = useState(true);
-  const [isFilterOpen, setIsFilterOpen] = useState(true);
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [ownerFilter, setOwnerFilter] = useState<'all' | 'personal' | string>('all');
   const [searchTerm, setSearchTerm] = useState('');
@@ -190,46 +190,48 @@ function DashboardContent() {
       <Head>
         <title>GitHub Actions Dashboard</title>
       </Head>
-      <div className="flex w-full max-w-none min-h-screen bg-white dark:bg-gray-900 relative">
-        {isFilterOpen && !isFullscreen && (
-          <div className="relative">
-            <FilterPanel
-              repos={repos}
-              selectedRepos={selectedRepos}
-              onRepoToggle={handleRepoSelection}
-              ownerFilter={ownerFilter}
-              setOwnerFilter={setOwnerFilter}
-              searchTerm={searchTerm}
-              setSearchTerm={setSearchTerm}
-              sortOrder={sortOrder}
-              setSortOrder={handleSortOrderChange}
-              sortBy={sortBy}
-              setSortBy={handleSortByChange}
-            />
-            <button
-              onClick={() => setIsFilterOpen(false)}
-              className="absolute top-4 -right-2 p-1.5 rounded-full bg-red-500 hover:bg-red-600 text-white shadow-lg transition-colors z-20"
-              title="Hide filters"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        )}
+      <div className="w-full max-w-none min-h-screen bg-white dark:bg-gray-900">
+        
         {!isFilterOpen && !isFullscreen && (
           <button
             onClick={() => setIsFilterOpen(true)}
             className="fixed top-4 left-4 z-20 p-2 rounded-full bg-blue-600 hover:bg-blue-700 text-white shadow-lg transition-colors"
             title="Show filters"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1V4zM3 10a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1v-2zM3 16a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-1 1H4a1 1 0 01-1-1v-2z"></path>
             </svg>
           </button>
         )}
-        <div className={`flex-1 ${!isFilterOpen && !isFullscreen ? 'pl-16' : 'px-8'}`}>
-          <div className="mb-8 flex justify-between items-start pt-4">
+
+        {/* Overlay */}
+        {isFilterOpen && !isFullscreen && (
+          <div 
+            onClick={() => setIsFilterOpen(false)} 
+            className="fixed inset-0 bg-black/60 z-30 transition-opacity"
+          ></div>
+        )}
+
+        {/* Sidebar */}
+        <div className={`fixed top-0 left-0 h-full bg-white dark:bg-gray-800 shadow-xl z-40 transition-transform transform ${isFilterOpen && !isFullscreen ? 'translate-x-0' : '-translate-x-full'} ease-in-out duration-300`}>
+          <FilterPanel
+            repos={repos}
+            selectedRepos={selectedRepos}
+            onRepoToggle={handleRepoSelection}
+            ownerFilter={ownerFilter}
+            setOwnerFilter={setOwnerFilter}
+            searchTerm={searchTerm}
+            setSearchTerm={setSearchTerm}
+            sortOrder={sortOrder}
+            setSortOrder={handleSortOrderChange}
+            sortBy={sortBy}
+            setSortBy={handleSortByChange}
+            onClose={() => setIsFilterOpen(false)}
+          />
+        </div>
+        
+        <div className={`flex-1 transition-all duration-300 ${!isFullscreen ? 'px-8' : ''}`}>
+          <div className={`mb-8 flex justify-between items-start pt-4 ${!isFullscreen ? 'pl-16' : ''}`}>
             <div>
               <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-gray-100">GitHub Actions Dashboard</h1>
               <p className="text-gray-600 dark:text-gray-400">Monitor your GitHub repositories and their action statuses.</p>
@@ -250,6 +252,8 @@ function DashboardContent() {
     </>
   );
 }
+
+
 
 export default function Dashboard() {
   return (

--- a/client/src/app/dashboard/page.tsx
+++ b/client/src/app/dashboard/page.tsx
@@ -213,7 +213,13 @@ function DashboardContent() {
         )}
 
         {/* Sidebar */}
-        <div className={`fixed top-0 left-0 h-full bg-white dark:bg-gray-800 shadow-xl z-40 transition-transform transform ${isFilterOpen && !isFullscreen ? 'translate-x-0' : '-translate-x-full'} ease-in-out duration-300`}>
+        <div 
+          role="dialog" 
+          aria-modal="true" 
+          aria-labelledby="filter-panel-title" 
+          className={`fixed top-0 left-0 h-full bg-white dark:bg-gray-800 shadow-xl z-40 transition-transform transform ${isFilterOpen && !isFullscreen ? 'translate-x-0' : '-translate-x-full'} ease-in-out duration-300`}
+        >
+          <h2 id="filter-panel-title" className="sr-only">Filter Panel</h2>
           <FilterPanel
             repos={repos}
             selectedRepos={selectedRepos}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,18 +1,19 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
-    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  darkMode: 'class',
+  darkMode: "class",
   theme: {
     extend: {
       screens: {
-        '3xl': '1800px',
+        "3xl": "1800px",
+        "4xl": "3440px"
       },
     },
   },
   plugins: [],
-}
+};
 


### PR DESCRIPTION
Replaces the previous static-panel implementation with a slide-over drawer for filtering repositories.

The new component is triggered by a floating filter icon, slides over the main content, and includes an overlay.

This improves the user experience and better accommodates long lists of items.